### PR TITLE
Add documentation for `$commentOnce()` action

### DIFF
--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1381,6 +1381,43 @@ workflows:
       - $close()
 ```
 
+## &nbsp; commentOnce
+______________
+
+**Description**:
+
+Comments a pull request once.
+
+If the comment is already present, then the action does nothing.
+
+**Parameters**:
+
+| variable           | type   | description                            |
+| ------------------ | ------ | -------------------------------------- |
+| `comment`          | string | body of the comment                    |
+
+**Return value**:
+
+*none*
+
+**Examples**:
+
+```yml
+$commentOnce("This is your first contribution! Thank you!")
+```
+
+A `revy.yml` example:
+
+```yml
+workflows:
+  - name: comment-pull-request
+    description: Comment pull request
+    if:
+      - rule: firstContribution
+    then:
+      - $commentOnce("This is your first contribution! Thank you!")
+```
+
 ## &nbsp; error :zap:
 
 | :zap: Professional Edition (*) |

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1313,41 +1313,6 @@ workflows:
       - $assignReviewer($group("seniors"), 2)
 ```
 
-## &nbsp; comment
-______________
-
-**Description**:
-
-Comments a pull request. Note that this comment will always be added whenever this action is executed. 
-
-**Parameters**:
-
-| variable  | type   | description         |
-| --------- | ------ | ------------------- |
-| `comment` | string | body of the comment |
-
-**Return value**:
-
-*none*
-
-**Examples**:
-
-```yml
-$comment("This is your first contribution! Thank you!")
-```
-
-A `reviewpad.yml` example:
-
-```yml
-workflows:
-  - name: comment-pull-request
-    description: Comment pull request
-    if:
-      - rule: firstContribution
-    then:
-      - $comment("This is your first contribution! Thank you!")
-```
-
 ## &nbsp; close
 ______________
 

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1421,7 +1421,7 @@ workflows:
       - $error("This pull request was considered too large.")
 ```
 
-## &nbsp info :zap:
+## &nbsp; info :zap:
 
 | :zap: Professional Edition (*) |
 | ------------------------------ |

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1352,9 +1352,9 @@ ______________
 
 **Description**:
 
-Comments a pull request. 
+Comments a pull request.
 
-Note that this comment will always be added whenever this action is executed. 
+Note that this comment will always be added whenever this action is executed.
 
 **Parameters**:
 

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1381,6 +1381,45 @@ workflows:
       - $close()
 ```
 
+
+## &nbsp; comment
+______________
+
+**Description**:
+
+Comments a pull request. 
+
+Note that this comment will always be added whenever this action is executed. 
+
+**Parameters**:
+
+| variable  | type   | description         |
+| --------- | ------ | ------------------- |
+| `comment` | string | body of the comment |
+
+**Return value**:
+
+*none*
+
+**Examples**:
+
+```yml
+$comment("This pull request has git conflicts. Please resolve them.")
+```
+
+A `reviewpad.yml` example:
+
+```yml
+workflows:
+  - name: conflict
+    description: Ask to resolve conflict
+    if:
+      - rule: hasConflicts
+    then:
+      - $comment("This pull request has git conflicts. Please resolve them.")
+```
+
+
 ## &nbsp; commentOnce
 ______________
 
@@ -1417,6 +1456,7 @@ workflows:
     then:
       - $commentOnce("This is your first contribution! Thank you!")
 ```
+
 
 ## &nbsp; error :zap:
 


### PR DESCRIPTION
This pull request introduces documentation for the `$commentOnce()` action.

Besides this, it was introduced the following:
- changed the placement of the `$comment()` action since it was placed in the *Functions* section when it should be placed in the *Actions*;
- added a semicolon to `&nbsp` before the `$info()` action documentation header - without this, the `nbsp` wasn't being formatted and it was showing in the docs as below:
  <img width="193" alt="image" src="https://user-images.githubusercontent.com/61353903/174639394-61baf09f-fa84-4642-8265-858a0507ccf6.png">

