### PR TITLE
Add $startsWith() docs

### DIFF
--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1101,6 +1101,43 @@ rules:
     spec: $isElementOf($author(), $group("junior"))
 ```
 
+## &nbsp; startsWith
+______________
+
+**Description**:
+
+Determines whether a text starts with a certain sentence, returning `true` or `false` as appropriate.
+
+**Parameters**:
+
+| variable         | type   | description                |
+| ---------------- | ------ | -------------------------- |
+| `text`           | string | The text to search in      |
+| `prefix` | string | The prefix |
+
+**Return value**:
+
+`boolean`
+
+Returns `true` if `prefix` is a prefix of `text`, `false` otherwise.
+
+**Examples**:
+
+```yml
+$startsWith("Testing string contains", "Test")     #true
+$startsWith("Testing string contains", "string contains")      #false
+```
+
+A `reviewpad.yml` example:
+
+```yml
+rules:
+  - name: isDevBranch
+    kind: patch
+    description: Verifies if the head branch of the pull requests starts with dev
+    spec: $startsWith($head(), "dev/ ")
+```
+
 ## Engine
 ______________
 

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -653,7 +653,7 @@ To know more about [GitHub Draft pull request](https://github.blog/2019-02-14-in
 
 `boolean`
 
-A boolean al.Value which is `true` if the pull request is `Draft`, `false` otherwise.
+A boolean which is `true` if the pull request is `Draft`, `false` otherwise.
 
 **Examples**:
 
@@ -1044,7 +1044,7 @@ Determines whether a text includes a certain sentence, returning `true` or `fals
 
 `boolean`
 
-Returns `true` if the al.Value searchSentence is found within the text, `false` otherwise.
+Returns `true` if searchSentence is found within the text, `false` otherwise.
 
 **Examples**:
 
@@ -1069,20 +1069,20 @@ ______________
 
 **Description**:
 
-Determines whether a list includes a certain al.Value among its entries, returning `true` or `false` as appropriate.
+Determines whether a list includes a certain value among its entries, returning `true` or `false` as appropriate.
 
 **Parameters**:
 
 | variable        | type      | description                |
 | --------------- | --------- | -------------------------- |
-| `searchElement` | literal   | The al.Value to search for |
+| `searchElement` | literal   | The value to search for    |
 | `list`          | []literal | The list to search in      |
 
 **Return value**:
 
 `boolean`
 
-Returns `true` if the al.Value searchElement is found within the list, `false` otherwise.
+Returns `true` if searchElement is found within the list, `false` otherwise.
 
 **Examples**:
 

--- a/aladino/builtins.md
+++ b/aladino/builtins.md
@@ -1113,7 +1113,7 @@ Determines whether a text starts with a certain sentence, returning `true` or `f
 | variable         | type   | description                |
 | ---------------- | ------ | -------------------------- |
 | `text`           | string | The text to search in      |
-| `prefix` | string | The prefix |
+| `prefix`         | string | The prefix                 |
 
 **Return value**:
 
@@ -1135,7 +1135,7 @@ rules:
   - name: isDevBranch
     kind: patch
     description: Verifies if the head branch of the pull requests starts with dev
-    spec: $startsWith($head(), "dev/ ")
+    spec: $startsWith($head(), "dev/")
 ```
 
 ## Engine


### PR DESCRIPTION
This pull request introduces the following changes:

- Documentation for the `startsWith` built-in;
- Fixes typos that originated from an incorrect search and replace of `Value` to `al.Value`.

[reviewpad-sig]: <>
[View on **Reviewpad**](https://beta.reviewpad.com/review/github.com/reviewpad/docs/pull/4)
