### PR TITLE
Update contribution document

### DIFF
--- a/versioned_docs/version-3.13.0/contributing/how-to-contribute.md
+++ b/versioned_docs/version-3.13.0/contributing/how-to-contribute.md
@@ -48,6 +48,13 @@ If you intend to change a piece of Reviewpad that is not yet being addressed on 
 
 If you're only fixing a bug, it's fine to submit a pull request right away but we still recommend to fill an issue detailing what you're fixing. This is helpful in case we don't accept that specific fix but want to keep track of the issue.
 
+### Contribution Prerequisites {#contribution-prerequisites} 
+
+-   You have [GO](https://go.dev) installed with minimum version of 1.18.2.
+-   You have [Taskfile](https://taskfile.dev/installation/) installed.
+-   You have `gcc` installed or are comfortable installing a compiler if needed. Some of our dependencies may require a compilation step. On OS X, the Xcode Command Line Tools will cover this. On Ubuntu, `apt-get install build-essential` will install the required packages. Similar commands should work on other Linux distros. Windows will require some additional steps, see the [`node-gyp` installation instructions](https://github.com/nodejs/node-gyp#installation) for details.
+-   You are familiar with Git.
+
 ### Your First Pull Request {#your-first-pull-request}
 
 Working on your first Pull Request? You can learn how from this free video series:
@@ -71,13 +78,6 @@ If you decide to fix an issue, please be sure to check the comment thread in cas
 7. Do a final check (`task check -f`).
 
 <!-- Add Contributor License Agreement (CLA) -->
-
-### Contribution Prerequisites {#contribution-prerequisites}
-
--   You have [GO](https://go.dev) installed with minimum version of 1.18.2.
--   You have [Taskfile](https://taskfile.dev/installation/) installed.
--   You have `gcc` installed or are comfortable installing a compiler if needed. Some of our dependencies may require a compilation step. On OS X, the Xcode Command Line Tools will cover this. On Ubuntu, `apt-get install build-essential` will install the required packages. Similar commands should work on other Linux distros. Windows will require some additional steps, see the [`node-gyp` installation instructions](https://github.com/nodejs/node-gyp#installation) for details.
--   You are familiar with Git.
 
 ### Development Workflow {#development-workflow}
 


### PR DESCRIPTION
## Description

As a new contributor in the [How to Contribute ](https://docs.reviewpad.com/contributing/how-to-contribute) document, I would like to move the [Contribution Prerequisites](https://docs.reviewpad.com/contributing/how-to-contribute#contribution-prerequisites) section to be located after the [Proposing a Change](https://docs.reviewpad.com/contributing/how-to-contribute#proposing-a-change) section.  The reason for it is because the first 7 sections deal with the guidelines of the organization; Code of Conduct, SemVer, Branch Org, Proposing a Change etc.  However, in order to create a pull request, you need the Prerequisites, which is why the location of the section would be better organized as mentioned above. 

## Related issue

Closes #115 

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [ ] I have run `yarn build` without any errors

## Code review and merge strategy (ship/show/ask)

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review -->
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge -->
<!-- - [ ] Ask: this pull request requires a code review before merge -->
