### PR TITLE
docs: Remove "waiting-for-review" label when approval given

### DIFF
--- a/docs/getting-started/onboarding-configuration.yml
+++ b/docs/getting-started/onboarding-configuration.yml
@@ -108,6 +108,9 @@ workflows:
       - rule: $isDraft() == false && $approvalsCount() < 1
         extra-actions:
           - $addLabel("waiting-for-review")
+      - rule: $isDraft() == false && $approvalsCount() > 0
+        extra-actions:
+          - $removeLabel("waiting-for-review")
 
   # This workflow labels pull requests based on the pull request change type.
   # This helps pick pull requests based on their change type.


### PR DESCRIPTION
## Description

When the PR has no approval yet, the label "waiting-for-review" is added.
This label is however not automatically removed when an approval is given.

This PR is a suggestion to automatically remove the label.

## Related issue

None, it's just a suggestion.

## Type of change

**Improvements** (non-breaking change without functionality) of the documentation

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [ ] I have run `yarn build` without any errors

## Code review and merge strategy (ship/show/ask)

**Ask**: this pull request requires a code review before merge since it's a suggestion
